### PR TITLE
Fix multiple issues related to class settings doing nothing.

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -91,7 +91,7 @@ class Popup {
         .popup.${this.id} {
             transition-duration: ${this.fadeTime};
             text-shadow: ${this.textShadow};
-            font-family: '${this.params.font ?? "Inter"}', 'Inter', Helvetica, sans-serif;
+            font-family: ${this.params.font ?? "Inter"}, 'Inter', Helvetica, sans-serif;
         }
         
         .popup.${this.id} .popup-content {
@@ -213,7 +213,7 @@ class Popup {
                 }
             }
             this.popupEl.classList.add("fade-in");
-            postShow(disableScroll);
+            postShow(this.disableScroll);
         }
 
         // hide popup on escape key press


### PR DESCRIPTION
1. `font`. The `font` option did nothing at all, no matter what font was passed. The issue was, in the css, single quotes being added in an improper way, causing a syntax error that prevented the font option from doing anything. 
2. `disableScroll`. I noticed that the `disableScroll` option was not working properly when `showImmediately` was enabled, and always prevented scrolling. This was caused by an incorrect passing of `disableScroll`, rather than `this.disableScroll` to the `disableScroll` function is being called, causing the function to be passed to itself, resulting in the nullish coalescing to always pick the default value.